### PR TITLE
NetKVM: Fix dropping IPv6 IPsec packets.

### DIFF
--- a/NetKVM/Common/sw_offload.cpp
+++ b/NetKVM/Common/sw_offload.cpp
@@ -955,6 +955,8 @@ BOOLEAN AnalyzeIP6Hdr(
         case PROTOCOL_UDP:
             __fallthrough;
         case IP6_HDR_FRAGMENT:
+            __fallthrough;
+        case IP6_HDR_ESP:
             return TRUE;
         case IP6_HDR_DESTINATION:
             {
@@ -986,8 +988,6 @@ BOOLEAN AnalyzeIP6Hdr(
             }
             break;
         case IP6_HDR_HOP_BY_HOP:
-            __fallthrough;
-        case IP6_HDR_ESP:
             __fallthrough;
         case IP6_HDR_AUTHENTICATION:
             __fallthrough;


### PR DESCRIPTION
Explicitly treat IPv6 ESP packet as usual packet (TCP, UDP, etc.).
ESP header should not be treated like other extension headers.
Because it does not start with 'Next Header' and 'Hdr Ext Len' fields and next header is encrypted.

Signed-off-by: yach-yf <90957906+yach-yf@users.noreply.github.com>